### PR TITLE
fixs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export function apply(context: Context, config: Config) {
 
   function MediaFormat (){
     // http://www.youtube.com/embed/m5yCOSHeYn4
-    var ytRegEx = /^(?:https?:\/\/)?(?:i\.|www\.|img\.)?(?:youtu\.be\/|youtube\.com\/|ytimg\.com\/)(?:embed\/|v\/|vi\/|vi_webp\/|watch\?v=|watch\?.+&v=)((\w|-){11})(?:\S+)?$/;
+    var ytRegEx = /(?:https?:\/\/)?(?:i\.|www\.|img\.)?(?:youtu\.be\/|youtube\.com\/|ytimg\.com\/)(?:shorts\/|embed\/|v\/|vi\/|vi_webp\/|watch\?v=|watch\?.+&v=)([\w-]{11})/;
     // http://vimeo.com/3116167, https://player.vimeo.com/video/50489180, http://vimeo.com/channels/3116167, http://vimeo.com/channels/staffpicks/113544877
     var vmRegEx = /https?:\/\/(?:vimeo\.com\/|player\.vimeo\.com\/)(?:video\/|(?:channels\/staffpicks\/|channels\/)|)((\w|-){7,9})/;
     // http://open.spotify.com/track/06TYfe9lyGQA6lfqo5szIi, https://embed.spotify.com/?uri=spotify:track:78z8O6X1dESVSwUPAAPdme
@@ -80,11 +80,15 @@ export function apply(context: Context, config: Config) {
     try {
       let id;
       if (session.content.includes('https://youtu.be')) {
-        const index = session.content.lastIndexOf("\/");
-        id = session.content.substring(index + 1,session.content.length);
+        id = session.content.match(/youtu\.be\/([\w-]{11})/)[1]
       } else {
         id = MediaFormat().getYoutubeID(session.content);
       }
+      if (!id) {
+        logger.warn('unable to perceive youtube id from' + session.content)
+        return next()
+      }
+      logger.info('perceived youtube id ' + id)
       const result = await fetchDataFromAPI(id);
       const snippet = result.items[0].snippet;
       const {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export const Config = Schema.object({
 const apiEndpointPrefix = 'https://www.googleapis.com/youtube/v3/videos';
 
 export function apply(context: Context, config: Config) {
-  const ctx = context.isolate(['http'])
+  const ctx = context.isolate('http')
   ctx.http = context.http.extend(config.quester)
 
   function MediaFormat (){


### PR DESCRIPTION
修复了以下问题：

1. 目前使用中间件匹配包含 youtube.com 或 youtu.be 的链接，但是正则限定了头尾没有其他东西，会导致匹配出 null 请求不到数据后台报错
2. 对于 youtu.be 的链接，第一个斜杠后的所有内容都会作为 id，会错误的把 urlParam 也作为 id 的一部分，也导致请求不到数据
3. shorts 链接匹配不到 id
4. cordis 3.12.0 改变了 ctx.isolate 的参数

没有修复的已知问题：

1. playlist 链接仍然匹配不到 id